### PR TITLE
Rectifications de la reponse à la question :Est-ce que tu peux savoir…

### DIFF
--- a/js/quiz_questions.js
+++ b/js/quiz_questions.js
@@ -343,7 +343,7 @@ var questions = [
             {
                 "text" : "Non",
                 "comment": "Tu as raison. Seuls un examen de la goutte épaisse ou un test de diagnostic rapide peuvent diagnostiquer le paludisme.",
-                "correct": false,
+                "correct": true,
             },
         ]
     },


### PR DESCRIPTION
… si quelqu’un a le paludisme rien qu’en le regardant, on ne distingue pas la bonne reponse car le parametre CORRECT etait aussi à FALSE sur toutes les propositions des reponses; voila pourquoi lorsque nous trouvons une questions, nous avons la reponse suivantes : Mauvaise reponse.Tu as raison. Seuls un examen de la goutte épaisse ou un test de diagnostic rapide peuvent diagnostiquer le paludisme. Nous avons alors distingué ces deux parametre. l'un à TRUE et l'autre à FALSE